### PR TITLE
Simplified Tree.cata

### DIFF
--- a/FSharp/ArchivePictures/Tree.fs
+++ b/FSharp/ArchivePictures/Tree.fs
@@ -7,9 +7,11 @@ module Tree =
     
     let node x xs = Node (x, xs)
 
-    let rec cata fd ff = function
-        | Leaf x -> ff x
-        | Node (x, xs) -> xs |> List.map (cata fd ff) |> fd x
+    let cata fd ff =
+        let rec loop = function
+            | Leaf x -> ff x
+            | Node (x, xs) -> xs |> List.map loop |> fd x
+        loop
 
     let choose f =
         cata (fun x -> List.choose id >> node x >> Some) (f >> Option.map Leaf)


### PR DESCRIPTION
Simplified the recursive part of `Tree.cata` by having it only take the one argument that changes.

I think this is easier to read.  The existing code has `fd` and `ff` passed into every recursive call, which suggests that those arguments vary among recursive calls, but they do not; they are always the same.